### PR TITLE
Fix setuptools v50.x remove six from 'extern'

### DIFF
--- a/nosedep.py
+++ b/nosedep.py
@@ -72,7 +72,12 @@ try:
     # Older versions of setuptools
     from setuptools.compat import reraise
 except ImportError:
-    from setuptools.extern.six import reraise
+    try:
+        from setuptools.extern.six import reraise
+    except ImportError:
+        # Fix setuptools v50.x remove six from 'extern'
+        # https://github.com/pypa/setuptools/commit/675d32ff667e90d239c95359007a58cb3aa88a97
+        from six import reraise
 from toposort import toposort
 
 dependencies = defaultdict(set)

--- a/nosedep.py
+++ b/nosedep.py
@@ -68,16 +68,7 @@ from itertools import chain, tee
 from nose.loader import TestLoader
 from nose.plugins import Plugin
 from nose.suite import ContextSuite
-try:
-    # Older versions of setuptools
-    from setuptools.compat import reraise
-except ImportError:
-    try:
-        from setuptools.extern.six import reraise
-    except ImportError:
-        # Fix setuptools v50.x remove six from 'extern'
-        # https://github.com/pypa/setuptools/commit/675d32ff667e90d239c95359007a58cb3aa88a97
-        from six import reraise
+from six import reraise
 from toposort import toposort
 
 dependencies = defaultdict(set)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 nose
 toposort
+six

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,10 @@ setup_args = dict(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Testing',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup_args = dict(
     name='nosedep',
-    version='0.7',
+    version='0.7.1',
     url='https://github.com/Zitrax/nose-dep',
     maintainer='Daniel Bengtsson',
     maintainer_email='daniel@bengtssons.info',


### PR DESCRIPTION
new setuptools version remove six pypa/setuptools@675d32f

I known introduce a new packet six, is not a good things, But there is no other way.